### PR TITLE
minimal raml document for web api defined by DemoController

### DIFF
--- a/demo-project/demo-api.raml
+++ b/demo-project/demo-api.raml
@@ -1,0 +1,88 @@
+#%RAML 1.0
+---
+title: Demo API
+baseUri: http://localhost:8080/
+
+/values:
+    get:
+      description: "Retrieve an array of value entries"
+      responses:
+        200:
+          body:
+            application/json:
+              example: |
+                [
+                    {
+                        "key": "k01",
+                        "value": "some value",
+                        "id": 1
+                    },
+                    {
+                        "key": "k02",
+                        "value": "another value",
+                        "id": 2
+                    }
+                ]
+    post:
+        description: "Create a new value entry"
+        body:
+          application/json:
+            type: value
+            example: |
+              {
+                  "key": "k0",
+                  "value": "a value",
+                  "id": null
+              }
+        responses:
+          201:
+            body:
+              application/json:
+                  example: |
+                      {
+                        "key": "k0",
+                        "value": "a value",
+                        "id": 1
+                      }
+            headers:
+                  Location:
+                    example: "http://localhost:8080/values/1"
+    /{id}:
+        put:
+            body:
+              application/json:
+                type: value
+                example: |
+                  {
+                      "key": "k0",
+                      "value": "a value",
+                      "id": null
+                  }
+            responses:
+              204:
+                  description: "successful update"
+
+types:
+  value: |
+    {
+      "type": "object",
+      "$schema": "http://json-schema.org/draft-03/schema",
+      "id": "http://jsonschema.net",
+      "required": true,
+      "properties": {
+        "key": {
+          "type": "string",
+          "required": true,
+          "minLength": 1
+        },
+        "value": {
+          "type": "string",
+          "required": true,
+          "minLength": 1
+        },
+         "id": {
+           "type": ["integer", "null"],
+           "required": false
+         }
+      }
+    }

--- a/demo-project/demo-api.raml
+++ b/demo-project/demo-api.raml
@@ -3,86 +3,59 @@
 title: Demo API
 baseUri: http://localhost:8080/
 
+types:
+  Value: !include ./schemas/value.json
+  Values: !include ./schemas/values.json
+
 /values:
     get:
-      description: "Retrieve an array of value entries"
+      description: "returns all values currently stored by the service"
       responses:
         200:
           body:
             application/json:
+              type: Values
               example: |
-                [
-                    {
-                        "key": "k01",
-                        "value": "some value",
-                        "id": 1
-                    },
-                    {
-                        "key": "k02",
-                        "value": "another value",
-                        "id": 2
-                    }
-                ]
-    post:
-        description: "Create a new value entry"
-        body:
-          application/json:
-            type: value
-            example: |
-              {
+                [{
                   "key": "k0",
                   "value": "a value",
-                  "id": null
+                  "id": 1
+                },
+                {
+                  "key": "k1",
+                  "value": "another value",
+                  "id": 2
+                }]
+
+    post:
+        description: "creates a new value, and returns its ID"
+        body:
+          application/json:
+            type: Value
+            example: |
+              {
+                "key": "key-0",
+                "value": "a value"
               }
         responses:
           201:
             body:
               application/json:
-                  example: |
-                      {
-                        "key": "k0",
-                        "value": "a value",
-                        "id": 1
-                      }
+                type: Value
             headers:
-                  Location:
-                    example: "http://localhost:8080/values/1"
+              Location:
+                example: "http://localhost:8080/values/1"
     /{id}:
         put:
+            description: "updates an existing value"
             body:
               application/json:
-                type: value
+                type: Value
                 example: |
                   {
-                      "key": "k0",
-                      "value": "a value",
-                      "id": null
+                    "key": "key-0",
+                    "value": "a value"
                   }
             responses:
               204:
                   description: "successful update"
-
-types:
-  value: |
-    {
-      "type": "object",
-      "$schema": "http://json-schema.org/draft-03/schema",
-      "id": "http://jsonschema.net",
-      "required": true,
-      "properties": {
-        "key": {
-          "type": "string",
-          "required": true,
-          "minLength": 1
-        },
-        "value": {
-          "type": "string",
-          "required": true,
-          "minLength": 1
-        },
-         "id": {
-           "type": ["integer", "null"],
-           "required": false
-         }
-      }
-    }

--- a/demo-project/schemas/value.json
+++ b/demo-project/schemas/value.json
@@ -1,0 +1,36 @@
+{
+  "id": "value.json",
+  "title": "Value schema",
+  "definitions": {
+    "value": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "id": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    }
+  }
+}
+
+
+
+
+
+
+

--- a/demo-project/schemas/values.json
+++ b/demo-project/schemas/values.json
@@ -1,0 +1,8 @@
+{
+  "title": "Values schema",
+  "type": "array",
+  "id": "",
+  "items": { "$ref": "./schemas/value.json#/definitions/value" }
+
+}
+


### PR DESCRIPTION
This RAML document describes the current demo API. I've validated the document here: [yaml-validator](https://codebeautify.org/yaml-validator) and verified that it produces jax-rs code with this tool: [raml-to-jax-rs](https://github.com/mulesoft-labs/raml-for-jax-rs/tree/master/raml-to-jaxrs).

Note that I'm using the same json schema structure for both read and create/update and therefore the id field is nullable. Is it better to use 2 different schema types - one for read (with id present) and one for create/update without the id field?
